### PR TITLE
An easier explanation for Grain effect in SynthLabConstants.py

### DIFF
--- a/SynthLab/SynthLabConstants.py
+++ b/SynthLab/SynthLabConstants.py
@@ -301,7 +301,7 @@ class SynthLabConstants:
     SAMPLEN = SAMPLEN
     INDEX = _('Index')
     GAIN = GAIN
-    GRAIN_INFO = _('The grain effect splits the sound in tiny bits which can be rearranged in time.')
+    GRAIN_INFO = _('The grain effect splits the sound in tiny bits which can be rearranged differently.')
     GRAIN_PARA1 = _('The pitch of grains.')
     GRAIN_PARA2 = _('The sample to be used.')
     GRAIN_PARA3 = _('The variation in pitch of grains.')


### PR DESCRIPTION
According to https://en.wikipedia.org/wiki/Granular_synthesis, 

> Multiple grains may be layered on top of each other, and may play at different speeds, phases, volume, and frequency, among other parameters.

So the time is not the only one parameter involved. The string should reflect that. 